### PR TITLE
fixed documentation for --fonts flag

### DIFF
--- a/docs/source/using_fonts.rst
+++ b/docs/source/using_fonts.rst
@@ -148,7 +148,7 @@ to process your script:
 
 .. code::
 
-    python --fonts myscript.py
+    python myscript.py --fonts
 
 In either case, you should get feedback from the script about this process:
 


### PR DESCRIPTION
The documentation had put the flag before the script which means the flag will be passed to the python exe rather than protograf